### PR TITLE
change default port from 8181 to 8778

### DIFF
--- a/.s2i/environment
+++ b/.s2i/environment
@@ -1,0 +1,1 @@
+AB_JOLOKIA_OFF=true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,4 +11,4 @@ spring:
   jpa:
     generate-ddl: true
 server:
-    port: 8181
+    port: 8778


### PR DESCRIPTION
This is to help smooth over some bumps with the fabric8/s2i-java image.
Also adds an environment variable to suppress jolokia, this ensures that
the port reassignment will work.