### PR TITLE
remove add rating tab from index

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -28,9 +28,6 @@
                         <li class="active" role="presentation">
                             <a href="/">Movie Rating</a>
                         </li>
-                        <li class="" role="presentation">
-                            <a href="/addratings.html">Add Rating</a>
-                        </li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
This change will remove the "Add Rating" tab from the index page, it
leaves the static page for the addratings.html in place so that we can
use it later for reference. The add rating page is still accessible by
direct url, but there are no links to it.