### PR TITLE
add connection notifications on submit error

### DIFF
--- a/src/main/java/io/radanalytics/jiminy/RatingsController.java
+++ b/src/main/java/io/radanalytics/jiminy/RatingsController.java
@@ -86,24 +86,27 @@ public class RatingsController {
 	@RequestMapping(method = RequestMethod.GET, path = "/api/predictor/{userid}")
 	@ResponseStatus(HttpStatus.ACCEPTED)
 	public ReportDAO getPrediction(@PathVariable("userid") String userid) {
-		LOGGER.info("Getting prediction report: {} ", userid);
-		ReportDAO report = null;
-		try {
-			report = PredictorUtils.fetchPredictions(userid,NUM_PREDICTIONS, predictorURL);
-			final List<ProductType> dataset = report.getDataSet();
+        LOGGER.info("Getting prediction report: {} ", userid);
+        ReportDAO report = null;
+        try {
+            report = PredictorUtils.fetchPredictions(userid,NUM_PREDICTIONS, predictorURL);
+            final List<ProductType> dataset = report.getDataSet();
 
-			List<Long> ids = dataset.stream().map(ProductType::getId).collect(Collectors.toList());
+            List<Long> ids = dataset.stream().map(ProductType::getId).collect(Collectors.toList());
 
-            Map<Long, String> descriptions = productService.findAllById(ids).stream().collect(Collectors.toMap(ProductDAO::getId, ProductDAO::getDescriptions));
+            if (ids.size() == 5) {
+                Map<Long, String> descriptions = productService.findAllById(ids).stream().collect(Collectors.toMap(ProductDAO::getId, ProductDAO::getDescriptions));
 
-            for (ProductType pt : dataset) {
-                pt.setDescription(descriptions.get(pt.getId()));
+                for (ProductType pt : dataset) {
+                    pt.setDescription(descriptions.get(pt.getId()));
+                }
+            } else {
+                report = null;
             }
-
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-		return report;
-		}
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return report;
+    }
 
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -32,6 +32,13 @@
                 </div>
             </div>
         </nav><span></span>
+
+        <div class="col col-cards-pf container-cards-pf fader">
+          <div class="cards col-xs-10 col-md-8">
+            <div id="notifications"></div>
+          </div>
+        </div>
+
         <div class="col col-cards-pf container-cards-pf fader">
             <div class="cards col-xs-10 col-md-8">
                 <div class="card-pf card-pf-accented">
@@ -60,23 +67,50 @@
     </div>
 </div>
 <script>
+var showNotification = function(msg) {
+  var html = '<div class="alert alert-warning alert-dismissable">' +
+    '<button type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+    '<span class="pficon pficon-close"></span>' +
+    '</button><span class="pficon pficon-warning-triangle-o"></span>' + msg + '</div>';
+
+  $('#notifications').append(html);
+};
+
+var clearNotifications = function() {
+  $('#notifications').empty();
+};
+
+var clearTable = function() {
+  $('#table1').empty();
+};
+
 $('form').submit(false);
 var displayReport= function(){
-var userId= $("#userRating").val();
+  clearTable();
+  clearNotifications();
+  var userId= $("#userRating").val();
 
- $.get("/api/predictor/"+userId,
-        function(data, status){
-			var conf={ columns: data.columns,
-		            data: data.dataSet,
-		            dom: "t",
-		            order: [[ 0, 'asc' ]],
-		            pfConfig: {
-		              filterCaseInsensitive: true,
-		              paginationSelector: "#pagination1",
-		              colvisMenuSelector: '.table-view-pf-colvis-menu'
-		            },
-		         };
-		    var table= $("#table1").DataTable(conf);
+  $.ajax("/api/predictor/"+userId)
+    .done(function(data) {
+      if (data == "") {
+        showNotification("Warning: empty ratings response, please try again or check the predictor service");
+      }
+      else {
+        var conf={ columns: data.columns,
+          data: data.dataSet,
+          dom: "t",
+          order: [[ 0, 'asc' ]],
+          pfConfig: {
+            filterCaseInsensitive: true,
+            paginationSelector: "#pagination1",
+            colvisMenuSelector: '.table-view-pf-colvis-menu'
+          },
+        };
+        var table= $("#table1").DataTable(conf);
+      }
+    })
+    .fail(function() {
+      showNotification("Warning: bad response from html-server, please check the server logs");
     });
 };
 </script>


### PR DESCRIPTION
This change adds some logic in the front-end to give a user
notifications when there is trouble getting prediction information from
the server. If the server returns an empty response or if the connection
fails, a notification will be displayed to the user.

Also adds a convenience method to clear the table when pressing submit.